### PR TITLE
chore: .gitignoreに除外対象を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ Thumbs.db
 .project
 .cproject
 builtins
+/FLYING/**
+
+/.vscode/**
+/debugger/*
+
+manifest.private.der
+manifest.public.der


### PR DESCRIPTION
# 概要
- #16 
- 除外対象のファイルを追加した
  - `.vscode/`
  - `/FLYING`
    - リポジトリからの除外は別issueで対応
  - `/debugger`
  - `manifest.*.der`