### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance RNG seeding with high entropy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-10-24 - Defold RNG Initialization Race Condition
+**Vulnerability:** Lua's `math.random` relies on global state. In Defold, script initialization order isn't strictly guaranteed across different game objects. If a script like `claypipe.script` initializes and uses `math.random` before the main controller `game_master.script` seeds the RNG, it will use the default seed, leading to predictable game state.
+**Learning:** Centralized seeding in a single script (like `game_master`) is insufficient in engines with non-deterministic initialization orders for distributed objects.
+**Prevention:** Each script that relies on RNG for critical game logic during its `init` phase must ensure the RNG is seeded, or the game architecture must guarantee a strict initialization order (e.g., a bootstrap script that spawns others). For this fix, we are adding redundant high-entropy seeding to critical components.

--- a/main/scripts/claypipe.script
+++ b/main/scripts/claypipe.script
@@ -1,3 +1,6 @@
+-- SECURITY: Import socket for high-entropy seeding
+local socket = require "socket"
+
 -- 定数
 local CLAYPIPE_MIN_Y = 252
 local CLAYPIPE_MAX_Y = 828
@@ -5,6 +8,10 @@ local CLAYPIPE_LIMIT_X = -432
 local CLAYPIPE_JUDGE_X = 600
 
 function init(self)
+	-- SECURITY: Ensure RNG is seeded even if this script loads before game_master
+	math.randomseed((socket.gettime() * 10000) % 4294967296)
+	math.random(); math.random(); math.random();
+
 	-- 土管の移動速度
 	self.SCROOL_SPEED = 12
 

--- a/main/scripts/game_master.script
+++ b/main/scripts/game_master.script
@@ -1,3 +1,6 @@
+-- SECURITY: Import socket for high-entropy seeding
+local socket = require "socket"
+
 local function send_instruction_to_gui(text)
 	msg.post("/gui/text#text", "instruction", {content = hash(text)})
 end
@@ -9,7 +12,8 @@ local function send_instruction_to_object(text)
 end
 
 function init(self)
-	math.randomseed(os.time())
+	-- SECURITY: Use high-entropy seeding to prevent predictable game states
+	math.randomseed((socket.gettime() * 10000) % 4294967296)
 	math.random();
 	math.random();
 	math.random();


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Predictable RNG initialization using `os.time()` (second precision) and race conditions in script initialization order.
**🎯 Impact:** Game state could be predictable if launched at the same second, or if `claypipe.script` initialized before `game_master.script`.
**🔧 Fix:** Switched to high-entropy `socket.gettime()` seeding and added redundant seeding to critical game objects.
**✅ Verification:** Verified syntax with `luac5.3`.

---
*PR created automatically by Jules for task [3022011484808259767](https://jules.google.com/task/3022011484808259767) started by @kou256*