### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak random number generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Medium] Fix weak random number generation
+**Vulnerability:** Weak PRNG seeding using `math.randomseed(os.time())`.
+**Learning:** In Lua, `os.time()` only provides second-level resolution, leading to predictable seeds if instances start within the same second. Defold environment has `socket` available which provides millisecond resolution with `socket.gettime()`.
+**Prevention:** Use high-entropy sources like `socket.gettime()` for seeding in Defold, and apply modulo to prevent integer overflows.

--- a/main/scripts/game_master.script
+++ b/main/scripts/game_master.script
@@ -9,7 +9,9 @@ local function send_instruction_to_object(text)
 end
 
 function init(self)
-	math.randomseed(os.time())
+	-- SECURITY: Use high-entropy seed to prevent predictable random numbers
+	local socket = require("socket")
+	math.randomseed((socket.gettime() * 10000) % 4294967296)
 	math.random();
 	math.random();
 	math.random();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Weak PRNG seeding using `math.randomseed(os.time())`. In Lua, `os.time()` only provides second-level resolution, leading to predictable seeds if instances start within the same second.
🎯 Impact: Predictable randomness in the game (e.g., claypipe spawn positions might be predictable).
🔧 Fix: Used `socket.gettime()` from the Defold environment, which provides millisecond resolution, and applied modulo arithmetic to prevent integer overflows.
✅ Verification: Ran `luac5.3 -p main/scripts/game_master.script` to ensure no syntax errors were introduced. Also logged the vulnerability to `.jules/sentinel.md` as per the security journaling guidelines.

---
*PR created automatically by Jules for task [18350174249766686235](https://jules.google.com/task/18350174249766686235) started by @kou256*