### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance RNG seeding with high-entropy source

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2024-05-18 - Weak Random Number Generator Seeding and Global State
+
+**Vulnerability:** The random number generator (RNG) was seeded with `os.time()`, leading to highly predictable outputs, especially when the game is restarted frequently.
+
+**Learning:** `os.time()` only changes once per second, making it an insufficiently granular seed for a game where the initial setup should vary dynamically. In Lua, `math.randomseed()` alters the global RNG state underneath (standard C `srand` function). Multiple rapid sequential calls to `math.randomseed` in different script initializations are actually an anti-pattern: if these initialize within the exact same timer tick, they'll write identical values to the global seed, effectively resetting the sequence mid-startup and degrading the true randomness of output values.
+
+**Prevention:** Use high-entropy seeding via the `socket` library's `gettime()` function. Calculate the seed via `math.randomseed((socket.gettime() * 10000) % 4294967296)` to incorporate sub-second precision and avoid potential integer overflow issues. Crucially, the RNG should be seeded **exactly once** at the very beginning of the application's lifecycle (e.g., inside the `init()` function of the main game loop / master script like `game_master.script`).

--- a/main/scripts/game_master.script
+++ b/main/scripts/game_master.script
@@ -8,8 +8,11 @@ local function send_instruction_to_object(text)
 	msg.post("/claypipe/controller#claypipe", "instruction", {content = hash(text)})
 end
 
+local socket = require 'socket'
+
 function init(self)
-	math.randomseed(os.time())
+	-- Use high-entropy seeding to prevent predictable RNG
+	math.randomseed((socket.gettime() * 10000) % 4294967296)
 	math.random();
 	math.random();
 	math.random();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Random Number Generator (RNG) was seeded with `os.time()`, which only updates once per second. This leads to highly predictable outputs, especially when the game is restarted frequently.
🎯 Impact: Predictable RNG compromises the dynamic nature of the game, allowing players to potentially anticipate obstacle patterns if they restart rapidly.
🔧 Fix: Replaced `os.time()` with the `socket` library's `gettime()` function. The seed is calculated via `math.randomseed((socket.gettime() * 10000) % 4294967296)` to incorporate sub-second precision and avoid potential integer overflow issues in Lua.
✅ Verification: Code syntax was checked using `luac5.3`. The changes were also reviewed for side effects (like accidental multiple seedings).

---
*PR created automatically by Jules for task [5385023352573800630](https://jules.google.com/task/5385023352573800630) started by @kou256*