### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak RNG seeding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Weak RNG Seeding in Lua
+**Vulnerability:** The application was using `os.time()` as the seed for Lua's `math.randomseed()`. `os.time()` only provides second-level resolution, making the random sequence highly predictable for concurrent or closely timed sessions, which can lead to exploitable game state generation.
+**Learning:** For game state and application logic requiring robust RNG, high-entropy seeds are essential. `socket.gettime()` from LuaSocket provides sub-second resolution. Furthermore, when using `socket.gettime() * 10000`, integer overflow in Lua 5.3+ or engine implementations can occur and ruin the entropy. Modulo arithmetic (e.g., `% 4294967296`) is necessary to prevent overflow issues and maintain valid seed ranges.
+**Prevention:** Always use `socket.gettime()` with proper modulo arithmetic (`(socket.gettime() * 10000) % 4294967296`) when seeding `math.random` in Defold/Lua projects instead of `os.time()`.

--- a/main/scripts/game_master.script
+++ b/main/scripts/game_master.script
@@ -9,7 +9,8 @@ local function send_instruction_to_object(text)
 end
 
 function init(self)
-	math.randomseed(os.time())
+	local socket = require("socket")
+	math.randomseed((socket.gettime() * 10000) % 4294967296)
 	math.random();
 	math.random();
 	math.random();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application seeded its random number generator (`math.randomseed()`) using `os.time()`. Because `os.time()` only provides one-second resolution, running multiple instances of the application simultaneously or in rapid succession results in identical game states/random sequences, making the application's behavior predictable and potentially exploitable for game manipulation.
🎯 Impact: Predictable game states and events. In an authoritative server context this could lead to logic bypass; in this client-side game, it allows perfect replayability across identical startup times, undermining the RNG-based game design.
🔧 Fix: Replaced `os.time()` with `socket.gettime()` from LuaSocket, which provides sub-second resolution for much higher entropy. Used `(socket.gettime() * 10000) % 4294967296` to safely scale the sub-second value while using modulo arithmetic to prevent integer overflows that ruin seed entropy.
✅ Verification: Ran `luac5.3 -p main/scripts/game_master.script` to verify no Lua syntax errors were introduced. Checked application logs to ensure game startup correctly pulls the new RNG seed. Added a new critical learning entry to `.jules/sentinel.md` documenting the fix.

---
*PR created automatically by Jules for task [1007711363143503319](https://jules.google.com/task/1007711363143503319) started by @kou256*