### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix weak RNG seeding

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Weak PRNG Seeding
+**Vulnerability:** The PRNG was seeded using `os.time()`, which only provides second-level resolution, leading to predictable sequences of random numbers if the application starts at the same second.
+**Learning:** In Lua/Defold, `math.randomseed(os.time())` does not offer sufficient entropy for games or applications needing less predictable randomness.
+**Prevention:** Use `socket.gettime()` combined with modulo arithmetic (`math.floor((socket.gettime() * 10000) % 4294967296)`) to seed the PRNG, ensuring sub-second resolution and sufficient entropy.

--- a/main/scripts/game_master.script
+++ b/main/scripts/game_master.script
@@ -1,3 +1,5 @@
+local socket = require("socket")
+
 local function send_instruction_to_gui(text)
 	msg.post("/gui/text#text", "instruction", {content = hash(text)})
 end
@@ -9,7 +11,7 @@ local function send_instruction_to_object(text)
 end
 
 function init(self)
-	math.randomseed(os.time())
+	math.randomseed(math.floor((socket.gettime() * 10000) % 4294967296))
 	math.random();
 	math.random();
 	math.random();


### PR DESCRIPTION
**🚨 Severity**: MEDIUM
**💡 Vulnerability**: The pseudorandom number generator (PRNG) was seeded using `os.time()`, which only provides second-level resolution. This leads to predictable sequences of random numbers if the application is started multiple times within the same second.
**🎯 Impact**: While primarily affecting the initial randomness of elements like the claypipe positions upon startup, predictable RNG can be a significant flaw in games, allowing players to anticipate initial game states or patterns.
**🔧 Fix**: Replaced `os.time()` with `socket.gettime()` combined with modulo arithmetic (`math.floor((socket.gettime() * 10000) % 4294967296)`). This provides a seed with sub-second (millisecond) resolution, significantly increasing entropy and preventing predictable initial states.
**✅ Verification**: 
1. The Lua file syntax was verified using `luac5.3 -p main/scripts/game_master.script`.
2. The `socket` library is correctly required at the top of the file.
3. The `.jules/sentinel.md` file was created and contains the critical learning about weak PRNG seeding.

---
*PR created automatically by Jules for task [12790326952915837901](https://jules.google.com/task/12790326952915837901) started by @kou256*