### PR TITLE
🛡️ Sentinel: [HIGH] Fix weak PRNG seeding in game_master.script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Weak PRNG Seeding in Lua
+**Vulnerability:** The random number generator was seeded with `os.time()`, which only provides 1-second resolution. This makes random events in the game highly predictable, especially if the application is started at a known time.
+**Learning:** `os.time()` is insufficient for seeding RNG where unpredictability is required, as it updates too slowly. Using a high-resolution timer from the `socket` library provides much better entropy.
+**Prevention:** Always use `socket.gettime()` (or a similarly high-resolution clock) combined with modulo arithmetic (`% 4294967296`) to ensure a valid integer seed when initializing `math.randomseed()` in Defold/Lua environments.

--- a/main/scripts/game_master.script
+++ b/main/scripts/game_master.script
@@ -9,7 +9,8 @@ local function send_instruction_to_object(text)
 end
 
 function init(self)
-	math.randomseed(os.time())
+	local socket = require("socket")
+	math.randomseed(math.floor((socket.gettime() * 10000) % 4294967296))
 	math.random();
 	math.random();
 	math.random();


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The random number generator (`math.randomseed`) was being initialized with `os.time()`, which only provides 1-second resolution. This predictable seed reduces entropy and can make the behavior of random elements in the application easily guessable if the application start time is known.
🎯 **Impact:** An attacker or player could predict RNG sequences, which can be exploited depending on game mechanics (e.g., predicting pipe generation or other pseudo-random events).
🔧 **Fix:** Changed the `math.randomseed` initialization to use `socket.gettime()`, which provides higher resolution timing, thereby significantly increasing entropy for the PRNG seed.
✅ **Verification:** Verified by checking syntax using `luac5.3 -p`. The change is contained within `main/scripts/game_master.script`'s `init()` function and correctly computes a modulus to keep the seed as a valid 32-bit integer.

---
*PR created automatically by Jules for task [9625758256709850768](https://jules.google.com/task/9625758256709850768) started by @kou256*